### PR TITLE
[Sage-1000] [Sage-1008] bug fix: rapid restart and resolve upload server more than once

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -113,7 +113,7 @@ upload_files() {
 
     echo "resolving upload server address"
     if ! resolve_upload_server_and_update_etc_hosts; then
-        echo "failed to resolve upload server and update /etc/hosts. retrying..."
+        echo "failed to resolve upload server and update /etc/hosts."
         return 1
     fi
 


### PR DESCRIPTION
This PR attempts to address two main problems:

1. Avoid rapid restarting of the service. This was most likely caused to a failure to resolve the upload server address at the beginning of the program. We now are more tolerant of this and retry before uploading files. (Sage-1008)

2. Because we retry resolving the upload server each time we upload files, we are more protected against the issue of uploads not occurring if the beehive DNS entry is updated. We will still be affected by the DNS cache time, but now we will at least eventually resolve to the correct address without manual intervention. (Sage-1000)

I did some refactoring of the main loop to make it easier to update the liveness probe when everything is working correctly.