### PR TITLE
Prune empty directories before uploading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.16.2
 WORKDIR /app
 RUN apk add --no-cache openssh-client rsync bash
 COPY . .

--- a/main.sh
+++ b/main.sh
@@ -158,7 +158,7 @@ find_uploads_in_cwd() {
     # with job
     # path:  ./Pluginctl/test-pipeline/0.2.8/1649746359093671949-a31446e4291ac3a04a3c331e674252a63ee95604/data
     # depth: 1     2         3           4                      5                                         files
-    find . -mindepth 3 -maxdepth 4 -type d | awk -F/ '
+    find . -mindepth 3 -maxdepth 4 -type d ! -empty | awk -F/ '
 # match paths which ends in version/timestamp-shasum
 $3 ~ /[0-9]+\.[0-9]+\.[0-9]+/ && $4 ~ /[0-9]+-[0-9a-f]+/
 $4 ~ /[0-9]+\.[0-9]+\.[0-9]+/ && $5 ~ /[0-9]+-[0-9a-f]+/
@@ -219,11 +219,6 @@ while true; do
 
     echo "scanning and uploading files..."
     find_uploads_in_cwd | while read -r dir; do
-        if ! ls "${dir}" | grep -q .; then
-            echo "skipping dir with no uploads: ${dir}"
-            continue
-        fi
-
         echo "uploading: ${dir}"
         upload_dir "${dir}"
         touch /tmp/rsync_healthy

--- a/main.sh
+++ b/main.sh
@@ -219,7 +219,7 @@ while true; do
     cd /uploads
 
     echo "cleaning up empty upload dirs..."
-    find . -type d -empty -delete
+    find . -mindepth 1 -type d -empty -delete
 
     echo "scanning and uploading files..."
     find_uploads_in_cwd | while read -r dir; do

--- a/main.sh
+++ b/main.sh
@@ -216,9 +216,12 @@ while true; do
         fatal "failed to resolve upload server and update /etc/hosts."
     fi
 
-    echo "scanning and uploading files..."
     cd /uploads
 
+    echo "cleaning up empty upload dirs..."
+    find . -type d -empty -delete
+
+    echo "scanning and uploading files..."
     find_uploads_in_cwd | while read -r dir; do
         if ! ls "${dir}" | grep -q .; then
             echo "skipping dir with no uploads: ${dir}"

--- a/main.sh
+++ b/main.sh
@@ -221,11 +221,8 @@ while true; do
     find_uploads_in_cwd | while read -r dir; do
         echo "uploading: ${dir}"
         upload_dir "${dir}"
-        touch /tmp/rsync_healthy
-
         # indicate that we are healthy and making progress after each transfer completes
-        touch /tmp/healthy
-
+        touch /tmp/rsync_healthy /tmp/healthy
         echo "done: ${dir}"
     done
 

--- a/main.sh
+++ b/main.sh
@@ -149,10 +149,6 @@ attempt_to_cleanup_dir() {
 rsync_supervisor &
 
 find_uploads_in_cwd() {
-    find . -mindepth 3 -maxdepth 3 -type d
-}
-
-find_uploads_in_cwd() {
     # NOTE(sean) upload data is mounted at /uploads with leaf files like:
     #
     # without job (default: sage)

--- a/main.sh
+++ b/main.sh
@@ -225,16 +225,12 @@ while true; do
     find_uploads_in_cwd | while read -r dir; do
         if ! ls "${dir}" | grep -q .; then
             echo "skipping dir with no uploads: ${dir}"
-            attempt_to_cleanup_dir "${dir}"
             continue
         fi
 
         echo "uploading: ${dir}"
         upload_dir "${dir}"
         touch /tmp/rsync_healthy
-
-        echo "cleaning up: ${dir}"
-        attempt_to_cleanup_dir "${dir}"
 
         # indicate that we are healthy and making progress after each transfer completes
         touch /tmp/healthy


### PR DESCRIPTION
I observed a case on W023 where the usual "remove empty dir after upload" was failing.

Specifically, I was getting some "read error" around where that step should have occurred. Only unusual thing I noticed was that there were _lots_ of empty dirs in the /upload tree. Manually removing the empty ones was enough to resolve the problem, though, I don't know if it was the root cause.

This PR adds that empty dir prune as a pre-step to uploading.