### PR TITLE
SAGE-1612: Adding retry to resolve upload server IP

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -51,6 +51,13 @@ echo "using username ${username}"
 mkdir -p /root/.ssh/controlmasters
 
 # define ssh config
+#
+# NOTE I'm using a workaround for a "Host key verification failed" issue by relying on
+# beehive-upload-server's IP to be resolve and added to /etc/host. (See call to
+# resolve_upload_server_and_update_etc_hosts helper function in main loop.)
+#
+# This seems to be because our upload server ssh cert uses name "beehive-upload-server".
+# Eventually, this should be updated to use the actual hostname of the upload server.
 cat <<EOF > /root/.ssh/config
 Host beehive-upload-server
     Port ${WAGGLE_BEEHIVE_UPLOAD_PORT}
@@ -64,10 +71,6 @@ Host beehive-upload-server
     ControlMaster auto
     ControlPersist 1m
 EOF
-
-# NOTE workaround for "Host key verification failed" issue. at the moment, this seems to be because
-# our upload server ssh cert uses name "beehive-upload-server". eventually, this should be updated
-# to use the actual hostname of the upload server.
 
 # create backup of original /etc/hosts file
 # NOTE used by the resolve_upload_server_and_update_etc_hosts function below.
@@ -212,8 +215,17 @@ upload_dir() {
 }
 
 while true; do
-    if ! resolve_upload_server_and_update_etc_hosts; then
-        fatal "failed to resolve upload server and update /etc/hosts."
+    echo "processing uploads..."
+
+    # resolve the upload server address ip
+    #
+    # NOTE We've seen a number of "unable to resolve host ip for beehive-uploads.sagecontinuum.org" in
+    # deployments. While we don't fully understand the issue yet, this will retry to address the possibility
+    # of a race condition. If it's a system level issue that requires a restart, the liveness probe will
+    # eventually take care of that.
+    while ! resolve_upload_server_and_update_etc_hosts; then
+        echo "failed to resolve upload server and update /etc/hosts. will retry..."
+        sleep 3
     fi
 
     echo "scanning and uploading files..."

--- a/main.sh
+++ b/main.sh
@@ -223,10 +223,10 @@ while true; do
     # deployments. While we don't fully understand the issue yet, this will retry to address the possibility
     # of a race condition. If it's a system level issue that requires a restart, the liveness probe will
     # eventually take care of that.
-    while ! resolve_upload_server_and_update_etc_hosts; then
+    while ! resolve_upload_server_and_update_etc_hosts; do
         echo "failed to resolve upload server and update /etc/hosts. will retry..."
         sleep 3
-    fi
+    done
 
     echo "scanning and uploading files..."
     cd /uploads


### PR DESCRIPTION
This PR was motivated by seeing a high number of restarts in wes-upload-agent with the following "unable to resolve host ip" error:

```
using credentials
ssh ca pubkey: /etc/upload-agent/ca.pub
ssh key: /etc/upload-agent/ssh-key
ssh cert: /etc/upload-agent/ssh-key-cert.pub
using username node-000048b02d3ae28e
unable to resolve host ip for beehive-uploads.sagecontinuum.org
fatal: failed to resolve upload server and update /etc/hosts.
```

While working to root cause this, I opened this PR to:

* Update the comments on the specific workarounds used in the code.
* Add retry logic to resolving upload server IP. (This should address cases where the root cause is a race condition or network blip.)